### PR TITLE
Update to openai 1.70.0

### DIFF
--- a/custom_components/openai_ha_speech/manifest.json
+++ b/custom_components/openai_ha_speech/manifest.json
@@ -12,7 +12,7 @@
     ],
     "config_flow": true,
     "requirements": [
-        "openai>=1.68.2"
+        "openai>=1.70.0"
     ],
     "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Updates openai dependency to 1.70.0.

In testing, this appears to not have the dependency error that .68 had.